### PR TITLE
Do not build all branches on push event

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,10 @@
 name: CI
 on:
   push:
+    branches:
+      - master
+    tags:
+      - v*
   pull_request:
   schedule:
     - cron: '0 0 * * 1'


### PR DESCRIPTION
Since everything happens via PRs, it is not necessary to build it for push events as well.