### PR TITLE
Update reckon to version that references a static grgit version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ plugins {
     id "maven-publish"
     id "jacoco"
     id "com.gradle.plugin-publish" version "0.20.0"
-    id 'org.ajoberstar.reckon' version "0.13.1"
+    id 'org.ajoberstar.reckon' version "0.13.2"
     id "org.sonarqube" version "3.3"
     id "be.vbgn.ci-detect" version "0.5.0"
     id "be.vbgn.dev-conventions.opinion" version "0.5.3"


### PR DESCRIPTION
This avoids breakage of newer grgit versions on this old Gradle version
